### PR TITLE
Bump version to 0.0.5 and removed autofocuser ValueError on bad conditions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "sqlite3worker",
     "statsmodels",
 ]
-version = '0.0.4'
+version = '0.0.5'
 
 [project.urls]
 "Homepage" = "https://github.com/dgegen/astrafocus"


### PR DESCRIPTION
Removed autofocus `ValueError`s on bad conditions.  Tests in Astra succeeded (see code [here](https://github.com/ppp-one/astra/blob/main/tests/test_observatory_running_schedule.py)), however, astrafocus pytests failed to run because of issues with my modified config.yaml (it didn't seem to like Astra generated fits files).

```
======================================================================================================= short test summary info ========================================================================================================
FAILED tests/test_analytic_response_autoffocuser.py::TestAutofocuser::test_autofocuser - ValueError: zero-size array to reduction operation minimum which has no identity
FAILED tests/test_analytic_response_autoffocuser.py::TestAutofocuser::test_autofocuser_single_sweep - ValueError: zero-size array to reduction operation minimum which has no identity
FAILED tests/test_non_parametric_respons_autofocuser.py::TestNonParametricResponseAutofocuser::test_non_parametric_response_autofocuser - ValueError: zero-size array to reduction operation minimum which has no identity
===================================================================================================== 3 failed, 18 passed in 2.45s =====================================================================================================
```